### PR TITLE
Añadir extracción de ID de usuario en restablecimiento

### DIFF
--- a/Campus_SantaAna/Campus.UI/App_Start/IdentityConfig.cs
+++ b/Campus_SantaAna/Campus.UI/App_Start/IdentityConfig.cs
@@ -33,10 +33,13 @@ namespace Campus.UI
 
             // Extraer la URL del mensaje original
             string resetUrl = ExtractUrlFromMessage(message.Body);
+            string id = ExtractId(resetUrl);
 
             // Reemplazar placeholders
             emailTemplate = emailTemplate.Replace("{RESET_URL}", resetUrl);
             emailTemplate = emailTemplate.Replace("{APP_NAME}", "Santa Ana a Un Click");
+            emailTemplate = emailTemplate.Replace("{USER_ID}", id);
+
 
             // Crear el mensaje
             var mailMessage = new MailMessage
@@ -78,6 +81,21 @@ namespace Campus.UI
                 return "#"; // URL por defecto si hay error
             }
         }
+        private string ExtractId(string resetUrl)
+        {
+            try
+            {
+                int startIndex = resetUrl.IndexOf("userId=") + 7;
+                int endIndex = resetUrl.IndexOf("&code", startIndex);
+                return resetUrl.Substring(startIndex, endIndex - startIndex);
+
+            }
+
+            catch
+            {
+                return "#"; // URL por defecto si hay error
+            }
+        }
     }
 
 
@@ -98,7 +116,7 @@ namespace Campus.UI
         {
         }
 
-        public static ApplicationUserManager Create(IdentityFactoryOptions<ApplicationUserManager> options, IOwinContext context) 
+        public static ApplicationUserManager Create(IdentityFactoryOptions<ApplicationUserManager> options, IOwinContext context)
         {
             var manager = new ApplicationUserManager(new UserStore<ApplicationUser>(context.Get<ApplicationDbContext>()));
             // Configure la lógica de validación de nombres de usuario
@@ -139,7 +157,7 @@ namespace Campus.UI
             var dataProtectionProvider = options.DataProtectionProvider;
             if (dataProtectionProvider != null)
             {
-                manager.UserTokenProvider = 
+                manager.UserTokenProvider =
                     new DataProtectorTokenProvider<ApplicationUser>(dataProtectionProvider.Create("ASP.NET Identity"));
             }
             return manager;

--- a/Campus_SantaAna/Campus.UI/Controllers/AccountController.cs
+++ b/Campus_SantaAna/Campus.UI/Controllers/AccountController.cs
@@ -196,7 +196,7 @@ namespace Campus.UI.Controllers
         private ApplicationUser CrearUsuario(RegisterViewModel model)
         {
             string numeroRamdon = rnd.Next(0, 100).ToString("D2");
-            var user = new ApplicationUser { UserName = model.Nombre.ToUpper().First() + model.Apellido + numeroRamdon, Email = model.Email };
+            var user = new ApplicationUser { UserName = model.Nombre.ToUpper().First() + model.Apellido.Trim() + numeroRamdon, Email = model.Email };
             return user;
         }
 
@@ -231,7 +231,7 @@ namespace Campus.UI.Controllers
             if (ModelState.IsValid)
             {
                 var user = await UserManager.FindByEmailAsync(model.Email);
-                if (user == null/* || !(await UserManager.IsEmailConfirmedAsync(user.Id))*/)
+                if (user == null)
                 {
                     // No revelar que el usuario no existe o que no está confirmado
                     return View("ForgotPasswordConfirmation");
@@ -260,9 +260,19 @@ namespace Campus.UI.Controllers
         //
         // GET: /Account/ResetPassword
         [AllowAnonymous]
-        public ActionResult ResetPassword(string code)
+        public async Task<ActionResult> ResetPassword(string userId,string code)
         {
-            return code == null ? View("Error") : View();
+            if (code == null || userId == null)
+                return View("Error");
+
+            // Crear el modelo con los datos necesarios
+            var model = new ResetPasswordViewModel
+            {
+                Code = code,
+                Id = userId,
+            };
+
+            return View(model);
         }
 
         //
@@ -276,7 +286,7 @@ namespace Campus.UI.Controllers
             {
                 return View(model);
             }
-            var user = await UserManager.FindByNameAsync(model.Email);
+            var user = await UserManager.FindByIdAsync(model.Id);
             if (user == null)
             {
                 // No revelar que el usuario no existe

--- a/Campus_SantaAna/Campus.UI/Models/AccountViewModels.cs
+++ b/Campus_SantaAna/Campus.UI/Models/AccountViewModels.cs
@@ -107,10 +107,10 @@ namespace Campus.UI.Models
 
     public class ResetPasswordViewModel
     {
-        [Required]
-        [EmailAddress]
-        [Display(Name = "Correo electrónico")]
-        public string Email { get; set; }
+        //[Required]
+        //[EmailAddress]
+        //[Display(Name = "Correo electrónico")]
+        //public string Email { get; set; }
 
         [Required]
         [StringLength(100, ErrorMessage = "El número de caracteres de {0} debe ser al menos {2}.", MinimumLength = 6)]
@@ -124,6 +124,7 @@ namespace Campus.UI.Models
         public string ConfirmPassword { get; set; }
 
         public string Code { get; set; }
+        public string Id { get; set; }
     }
 
     public class ForgotPasswordViewModel

--- a/Campus_SantaAna/Campus.UI/Views/Account/ResetPassword.cshtml
+++ b/Campus_SantaAna/Campus.UI/Views/Account/ResetPassword.cshtml
@@ -13,12 +13,7 @@
         <hr />
         @Html.ValidationSummary("", new { @class = "text-danger" })
         @Html.HiddenFor(model => model.Code)
-        <div class="row">
-            @Html.LabelFor(m => m.Email, new { @class = "col-md-2 col-form-label" })
-            <div class="col-md-10">
-                @Html.TextBoxFor(m => m.Email, new { @class = "form-control" })
-            </div>
-        </div>
+        @Html.HiddenFor(model => model.Id)
         <div class="row">
             @Html.LabelFor(m => m.Password, new { @class = "col-md-2 col-form-label" })
             <div class="col-md-10">

--- a/Campus_SantaAna/Campus.UI/Views/Account/ResetPasswordEmail.cshtml
+++ b/Campus_SantaAna/Campus.UI/Views/Account/ResetPasswordEmail.cshtml
@@ -29,19 +29,19 @@
                                     Hemos recibido una solicitud para restablecer la contraseña de tu cuenta.
                                 </p>
                             </div>
-                            
+                            <input type='hidden' id='userId' value='{USER_ID}' />
                             <div style='text-align: center; margin: 40px 0;'>
                                 <a href='{RESET_URL}' style='display: inline-block; padding: 15px 30px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; border-radius: 25px; font-size: 16px; font-weight: bold; box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);'>
                                     ✨ Restablecer mi Contraseña
                                 </a>
                             </div>
-                            
+
                             <div style='background-color: #f8f9fa; padding: 20px; border-radius: 8px; border-left: 4px solid #667eea; margin: 30px 0;'>
                                 <p style='color: #495057; font-size: 14px; margin: 0; line-height: 1.5;'>
                                     <strong>⏰ Importante:</strong> Este enlace expirará en <strong>24 horas</strong> por razones de seguridad.
                                 </p>
                             </div>
-                            
+
                             <div style='text-align: center; margin-top: 30px;'>
                                 <p style='color: #666666; font-size: 14px; line-height: 1.6;'>
                                     Si no solicitaste este cambio, puedes ignorar este mensaje de forma segura.<br>


### PR DESCRIPTION
Se ha implementado la extracción del ID de usuario desde la URL de restablecimiento de contraseña en `IdentityConfig.cs`, permitiendo su inclusión en el correo electrónico de restablecimiento. Se ha creado el método `ExtractId` para manejar esta extracción de forma segura.

Además, se han realizado cambios en `AccountController.cs` para utilizar el ID del usuario en lugar del correo electrónico durante el proceso de restablecimiento. Se ha actualizado el modelo `ResetPasswordViewModel` para incluir el ID del usuario y se han comentado las validaciones del correo electrónico.

En la vista `ResetPassword.cshtml`, se ha eliminado el campo de entrada para el correo electrónico y se ha añadido un campo oculto para el ID. También se han mejorado los mensajes en `ResetPasswordEmail.cshtml` para incluir información sobre la expiración del enlace de restablecimiento.